### PR TITLE
[Feat #25] 미션 진행도 증가 및 랭크 업데이트 로직 구현

### DIFF
--- a/src/main/java/com/fillin/controller/report/ReportImageDetailController.java
+++ b/src/main/java/com/fillin/controller/report/ReportImageDetailController.java
@@ -30,6 +30,7 @@ public class ReportImageDetailController {
         return reportImageDetailService.createFeedback(memberId, reportId, type);
     }
 
+    @Operation(summary = "좋아요 토글", description = "제보에 대한 좋아요(저장) 토글입니다. 본인의 제보에 좋아요를 누를 수 없습니다.")
     @PostMapping("/{reportId}/like")
     public Response<LikeResponseDto> likeToggle(@PathVariable Long reportId, Long memberId){
         return reportImageDetailService.toggleLike(memberId, reportId);

--- a/src/main/java/com/fillin/domain/Member.java
+++ b/src/main/java/com/fillin/domain/Member.java
@@ -70,8 +70,21 @@ public class Member extends BaseTimeEntity {
         this.status = status;
     }
 
-    @Builder
+    public void updateAchievement(Achievement achievement) {
+        this.achievement = achievement;
+    }
 
+    public void updateBoangwan(Boangwan newRank) {
+        this.boangwan = newRank;
+    }
+
+    public void updateHaegyeolsa(Haegyeolsa newRank) {
+        this.haegyoelsa = newRank;
+    }
+
+    public void updateTamheomga(Tamheomga newRank) {
+        this.tamheomga = newRank;
+    }
 
     public void updateProfileInfo(ProfileRequestDto dto) {
         // 닉네임이 요청에 포함된 경우에만 업데이트

--- a/src/main/java/com/fillin/domain/MemberMission.java
+++ b/src/main/java/com/fillin/domain/MemberMission.java
@@ -24,8 +24,17 @@ public class MemberMission { // 유저별 미션 진행도
     @JoinColumn(name = "mission_id")
     private Mission mission;
 
-    private int progressCount; // 현재 달성 횟수 (progress_int -> progressCount 명명 수정 권장)
+    private int progressCount;
 
     private Boolean isComplete;
     private LocalDateTime completedAt;
+
+    public void addProgress() {
+        this.progressCount++;
+    }
+
+    public void complete() {
+        this.isComplete = true;
+        this.completedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/fillin/domain/Mission.java
+++ b/src/main/java/com/fillin/domain/Mission.java
@@ -22,5 +22,4 @@ public class Mission extends BaseTimeEntity{ // 미션 마스터 정보
     private ReportCategory category; // 관련 카테고리 (위험, 불편 등)
 
     private int targetCount; // 목표 횟수
-    private int exp;         // 보상 경험치
 }

--- a/src/main/java/com/fillin/domain/enums/Achievement.java
+++ b/src/main/java/com/fillin/domain/enums/Achievement.java
@@ -2,5 +2,15 @@ package com.fillin.domain.enums;
 
 //총 제보 갯수에 따라 0~9개 루키, 10~29 베테랑, 30~ 마스터
 public enum Achievement {
-    ROOKIE, MASTER, VETERAN
+    ROOKIE, VETERAN, MASTER;
+
+    public static Achievement resolveAchievement(int count) {
+        if(count <= 9){
+            return Achievement.ROOKIE;
+        }
+        else if(count <= 29){
+            return Achievement.VETERAN;
+        }
+        else return Achievement.MASTER;
+    }
 }

--- a/src/main/java/com/fillin/domain/enums/rank/Boangwan.java
+++ b/src/main/java/com/fillin/domain/enums/rank/Boangwan.java
@@ -1,7 +1,9 @@
 package com.fillin.domain.enums.rank;
 
 import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Getter;
 
+@Getter
 public enum Boangwan {
     BOANGWAN_0("보안관 0",0),
     BOANGWAN_1("보안관 1",5),
@@ -12,10 +14,21 @@ public enum Boangwan {
 
     @JsonValue
     private final String displayName;
+    @Getter
     private final int minReport;
 
     Boangwan(String displayName, int minReport) {
         this.displayName = displayName;
         this.minReport = minReport;
+    }
+
+    public static Boangwan resolveBoangwanRank(int count) {
+        Boangwan[] ranks = values();
+        for (int i = ranks.length - 1; i >= 0; i--) {
+            if (count >= ranks[i].minReport) {
+                return ranks[i];
+            }
+        }
+        return BOANGWAN_0; // 기본값
     }
 }

--- a/src/main/java/com/fillin/domain/enums/rank/Haegyeolsa.java
+++ b/src/main/java/com/fillin/domain/enums/rank/Haegyeolsa.java
@@ -1,7 +1,9 @@
 package com.fillin.domain.enums.rank;
 
 import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Getter;
 
+@Getter
 public enum Haegyeolsa {
     HAEGYEOLSA_0("해결사 0",0),
     HAEGYEOLSA_1("해결사 1",5),
@@ -17,5 +19,15 @@ public enum Haegyeolsa {
     Haegyeolsa(String displayName, int minReport) {
         this.displayName = displayName;
         this.minReport = minReport;
+    }
+
+    public static Haegyeolsa resolveHaegyeolsaRank(int count) {
+        for (int i = Haegyeolsa.values().length - 1; i >= 0; i--) {
+            Haegyeolsa rank = Haegyeolsa.values()[i];
+            if (count >= rank.getMinReport()) { // Boangwan에 getter 필요
+                return rank;
+            }
+        }
+        return Haegyeolsa.HAEGYEOLSA_0;
     }
 }

--- a/src/main/java/com/fillin/domain/enums/rank/Tamheomga.java
+++ b/src/main/java/com/fillin/domain/enums/rank/Tamheomga.java
@@ -1,7 +1,9 @@
 package com.fillin.domain.enums.rank;
 
 import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Getter;
 
+@Getter
 public enum Tamheomga {
     TAMHEOMGA_0("탐험가 0",0),
     TAMHEOMGA_1("탐험가 1",5),
@@ -17,5 +19,15 @@ public enum Tamheomga {
     Tamheomga(String displayName, int minReport) {
         this.displayName = displayName;
         this.minReport = minReport;
+    }
+
+    public static Tamheomga resolveTamheomgaRank(int count) {
+        for (int i = Tamheomga.values().length - 1; i >= 0; i--) {
+            Tamheomga rank = Tamheomga.values()[i];
+            if (count >= rank.getMinReport()) {
+                return rank;
+            }
+        }
+        return Tamheomga.TAMHEOMGA_0;
     }
 }

--- a/src/main/java/com/fillin/global/event/ReportCreatedEvent.java
+++ b/src/main/java/com/fillin/global/event/ReportCreatedEvent.java
@@ -1,0 +1,8 @@
+package com.fillin.global.event;
+
+import com.fillin.domain.enums.ReportCategory;
+
+public record ReportCreatedEvent(
+        Long memberId,
+        ReportCategory category
+) {}

--- a/src/main/java/com/fillin/repository/mission/MemberMissionRepository.java
+++ b/src/main/java/com/fillin/repository/mission/MemberMissionRepository.java
@@ -1,0 +1,14 @@
+package com.fillin.repository.mission;
+
+import com.fillin.domain.Member;
+import com.fillin.domain.MemberMission;
+import com.fillin.domain.enums.ReportCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface MemberMissionRepository extends JpaRepository<MemberMission, Long> {
+    List<MemberMission> findByMemberAndMission_CategoryAndIsCompleteFalse(Member member, ReportCategory category);
+}

--- a/src/main/java/com/fillin/repository/mission/MissionRepository.java
+++ b/src/main/java/com/fillin/repository/mission/MissionRepository.java
@@ -1,0 +1,9 @@
+package com.fillin.repository.mission;
+
+import com.fillin.domain.Mission;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MissionRepository extends JpaRepository<Mission, Long> {
+}

--- a/src/main/java/com/fillin/service/mission/listener/MissionEventListener.java
+++ b/src/main/java/com/fillin/service/mission/listener/MissionEventListener.java
@@ -1,0 +1,100 @@
+package com.fillin.service.mission.listener;
+
+import com.fillin.domain.Member;
+import com.fillin.domain.MemberMission;
+import com.fillin.domain.enums.Achievement;
+import com.fillin.domain.enums.ReportCategory;
+import com.fillin.domain.enums.rank.Boangwan;
+import com.fillin.domain.enums.rank.Haegyeolsa;
+import com.fillin.domain.enums.rank.Tamheomga;
+import com.fillin.global.apiPayload.code.ErrorCode;
+import com.fillin.global.apiPayload.exception.GlobalException;
+import com.fillin.global.apiPayload.response.Response;
+import com.fillin.global.event.ReportCreatedEvent;
+import com.fillin.repository.member.MemberRepository;
+import com.fillin.repository.mission.MemberMissionRepository;
+import com.fillin.repository.mission.MissionRepository;
+import com.fillin.repository.report.ReportRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class MissionEventListener {
+    private final MemberRepository memberRepository;
+    private final MissionRepository missionRepository;
+    private final MemberMissionRepository memberMissionRepository;
+    private final ReportRepository reportRepository;
+
+    @EventListener
+    @Transactional
+    public void handleReportCreated(ReportCreatedEvent event) {
+        Member member = memberRepository.findById(event.memberId())
+                .orElseThrow(() -> new GlobalException(ErrorCode.USER_NOT_FOUND));
+
+        // 1. 미션 진행도 업데이트
+        updateMissionProgress(member, event.category());
+
+        // 2. 랭크 재산정 및 업데이트
+        updateMemberRank(member, event.category());
+    }
+
+    // 미션 진행도 증가 로직
+    private void updateMissionProgress(Member member, ReportCategory category) {
+        // 진행 중인 미션 중 해당 카테고리와 일치하는 미션 조회
+        List<MemberMission> missions = memberMissionRepository.findByMemberAndMission_CategoryAndIsCompleteFalse(member, category);
+
+        for (MemberMission mm : missions) {
+            mm.addProgress(); // 진행도 +1 (MemberMission 엔티티에 메서드 추가 필요)
+
+            // 목표 달성 확인
+            if (mm.getProgressCount() >= mm.getMission().getTargetCount()) {
+                mm.complete(); // 완료 처리 (MemberMission 엔티티에 메서드 추가 필요)
+            }
+        }
+    }
+
+    // 랭크 업데이트 로직
+    private void updateMemberRank(Member member, ReportCategory category) {
+
+        //총 제보 수
+        int totalCount = reportRepository.countByMemberId(member.getId());
+
+        Achievement newAchieve = Achievement.resolveAchievement(totalCount);
+        if(member.getAchievement() != newAchieve){
+            member.updateAchievement(newAchieve);
+        }
+
+        // 해당 카테고리의 총 제보 수 조회 (ReportRepository 활용)
+        int categoryCount = reportRepository.countByMemberIdAndCategory(member.getId(), category);
+
+        switch (category) {
+            case DANGER -> {
+                Boangwan newRank = Boangwan.resolveBoangwanRank(categoryCount);
+                if (member.getBoangwan() != newRank) {
+                    member.updateBoangwan(newRank);
+                }
+            }
+            case INCONVENIENCE -> {
+                Haegyeolsa newRank = Haegyeolsa.resolveHaegyeolsaRank(categoryCount);
+                if (member.getHaegyoelsa() != newRank) {
+                    member.updateHaegyeolsa(newRank);
+                }
+            }
+            case DISCOVERY -> {
+                Tamheomga newRank = Tamheomga.resolveTamheomgaRank(categoryCount);
+                if (member.getTamheomga() != newRank) {
+                    member.updateTamheomga(newRank);
+                }
+            }
+        }
+    }
+
+
+}


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

- feat/mission
- #25

## 🔑 주요 내용

- 이벤트 리스너를 통한 achievement/rank 변경
- todo : 마스터미션 (고정) 생성 및 멤버 가입 시 이벤트 발행으로 자동 memberMission 객체 생성
- todo2: 멤버 생성 api에 이벤트 퍼블리셔 코드 넣기

## Check List

- [ ] **Reviewers** 등록을 하였나요?
- [ ] **Assignees** 등록을 하였나요?
- [ ] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!